### PR TITLE
fix: do not send proprietiesChanged signal for position

### DIFF
--- a/aionowplaying/interface/mpris2.py
+++ b/aionowplaying/interface/mpris2.py
@@ -37,6 +37,8 @@ class MprisPlayerServiceInterface(ServiceInterface):
 
     def set_property(self, name: str, value: Any):
         setattr(self._properties, name, value)
+        if name == PlaybackPropertyName.Position:
+            return
         if isinstance(value, PlaybackProperties.MetadataBean):
             value = DBusBeanMapper.metadata(value)
         self.emit_properties_changed({name: value})


### PR DESCRIPTION
The org.freedesktop.DBus.Properties.PropertiesChanged signal is not emitted when this property changes.

https://specifications.freedesktop.org/mpris-spec/2.2/Player_Interface.html#Property:Position

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>